### PR TITLE
fix for tile img position mobile breakpoint

### DIFF
--- a/index.css
+++ b/index.css
@@ -690,13 +690,6 @@ body,
     }
 }
 
-@media (max-width: 568px) {
-        .StoryTiles .Tile:nth-of-type(5n+1) .Tile--image {
-        top: 30%;
-    }
-}
-
-
 .StoryTiles .text-part {
     pointer-events: none;
 }


### PR DESCRIPTION
removed this style as it pushes image position out on the mobile breakpoint