### PR TITLE
Fix layout issues in IE9

### DIFF
--- a/index.css
+++ b/index.css
@@ -433,7 +433,7 @@ body,
     flex: 1 1 25%;
     border-right: 10px solid #000;
     position: relative;
-    width: 25%;
+    width: 24.99999%;
     float: left;
 }
 


### PR DESCRIPTION
I know this looks totally crazy, but it fixes a lot of the layout issues in IE9, meanwhile it has no impact in other browsers, as at 1190 the difference between `25%` and `24.99999%` is .1 of a pixel, which gets normalised out. 