### PR TITLE
Added credits to the storytiles

### DIFF
--- a/index.css
+++ b/index.css
@@ -767,3 +767,39 @@ body,
         max-height: 220px;
     }
 }
+
+/* Credits styles */
+.credits  {
+  padding-top: 50px;
+  padding-bottom: 50px;
+}
+.credits h3 {
+  font-size: 12px;
+  font-family: 'Neutra2Display';
+  margin: 0;
+  text-transform: uppercase;
+  padding: 0 30px;
+  color: #D2D6D9;
+}
+.credits p {
+  margin-bottom: 11px;
+  margin-top: 0;
+  font-size: 15px;
+  line-height: 22px;
+  padding: 0 30px;
+  color: #929CA2;
+}
+
+@media (max-width: 961px) {
+    .credits h3,
+    .credits p {
+        padding: 0px 30px;
+    }
+}
+
+@media (max-width: 568px) {
+    .credits h3,
+    .credits p {
+      padding: 0 14px;
+    }
+}

--- a/index.css
+++ b/index.css
@@ -771,7 +771,7 @@ body,
 /* Credits styles */
 .StoryTiles .credits  {
   padding-top: 50px;
-  padding-bottom: 50px;
+  padding-bottom: 20px;
 }
 .StoryTiles .credits h3 {
   font-size: 12px;
@@ -779,7 +779,7 @@ body,
   margin: 0;
   text-transform: uppercase;
   padding: 0 30px;
-  color: #D2D6D9;
+  color: #929CA2;
 }
 .StoryTiles .credits p {
   margin-bottom: 11px;

--- a/index.css
+++ b/index.css
@@ -769,11 +769,11 @@ body,
 }
 
 /* Credits styles */
-.credits  {
+.StoryTiles .credits  {
   padding-top: 50px;
   padding-bottom: 50px;
 }
-.credits h3 {
+.StoryTiles .credits h3 {
   font-size: 12px;
   font-family: 'Neutra2Display';
   margin: 0;
@@ -781,7 +781,7 @@ body,
   padding: 0 30px;
   color: #D2D6D9;
 }
-.credits p {
+.StoryTiles .credits p {
   margin-bottom: 11px;
   margin-top: 0;
   font-size: 15px;
@@ -791,15 +791,15 @@ body,
 }
 
 @media (max-width: 961px) {
-    .credits h3,
-    .credits p {
+    .StoryTiles .credits h3,
+    .StoryTiles .credits p {
         padding: 0px 30px;
     }
 }
 
 @media (max-width: 568px) {
-    .credits h3,
-    .credits p {
+    .StoryTiles .credits h3,
+    .StoryTiles .credits p {
       padding: 0 14px;
     }
 }

--- a/index.es6
+++ b/index.es6
@@ -6,7 +6,6 @@ import Authenticated from '@economist/component-authenticated';
 
 const authenticated = new Authenticated();
 const articleStore = new ArticleStore('/content');
-
 export default class StoryTiles extends React.Component {
 
   constructor() {
@@ -71,7 +70,7 @@ export default class StoryTiles extends React.Component {
                 return <Tile key={key} wide={key % 5 + 2} id={article.id} ref="animatedTile" />;
               })}
             </div>
-            <div className="credits">
+            <aside className="credits">
               <h3>Photo credits in order of appearance:</h3>
               <p>Getty Images, Alamy, Alamy, AP, Reuters, Getty Images,
               Getty Images, Alamy, Alamy, Barcroft, Alamy, Alamy, Alamy, Alamy,
@@ -84,7 +83,7 @@ export default class StoryTiles extends React.Component {
               from the cover:</h3>
               <p>Matt Herring, Florian Schommer, Alex Williamson, KAL,
                Gary Neill, Otto Steininger, Florian Schommer.</p>
-            </div>
+            </aside>
           </div>
         </div>
          <Omniture

--- a/index.es6
+++ b/index.es6
@@ -6,6 +6,7 @@ import Authenticated from '@economist/component-authenticated';
 
 const authenticated = new Authenticated();
 const articleStore = new ArticleStore('/content');
+
 export default class StoryTiles extends React.Component {
 
   constructor() {
@@ -69,6 +70,20 @@ export default class StoryTiles extends React.Component {
               {articles.map((article, key) => {
                 return <Tile key={key} wide={key % 5 + 2} id={article.id} ref="animatedTile" />;
               })}
+            </div>
+            <div className="credits">
+              <h3>Photo credits in order of appearance:</h3>
+              <p>Getty Images, Alamy, Alamy, AP, Reuters, Getty Images,
+              Getty Images, Alamy, Alamy, Barcroft, Alamy, Alamy, Alamy, Alamy,
+              Alamy, Alamy, Reuters, Bloomberg, University of Surrey, Reuters,
+              Alamy, Alamy, Reuters, Majority World, Majority World, Alamy, EPA,
+               AP, AFP, Reuters, Reuters, Eyevine, Eyevine, Getty Images,
+               Bill & Melinda Gates Foundation/Frederic Courbet, Alamy,
+               Getty Images, Getty Images, Eyevine, Alamy.</p>
+              <h3>Illustration credits in order of appearance
+              from the cover:</h3>
+              <p>Matt Herring, Florian Schommer, Alex Williamson, KAL,
+               Gary Neill, Otto Steininger, Florian Schommer.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Provide a credits-footer for the wordl-if landing.

To provide reusability of the storytiles component I think this is a temporary implementation.
IMHO credits shouldn't be on the Storytiles component but added in the App component or composed with the storytiles via an intermediate component.